### PR TITLE
make post content scrollable for mobile devices

### DIFF
--- a/_sass/post.scss
+++ b/_sass/post.scss
@@ -4,6 +4,11 @@
   text-align: center;
 }
 
+.post-content {
+  // scrollable for mobile devices
+  overflow-x: scroll;
+}
+
 .post-content p {
   line-height: 20px;
 }


### PR DESCRIPTION
For huge tables, we are not able to view theirs [full contents](https://y0yang.com/posts/compiler-pass-checklist) on mobile devices, this makes it scrollable.

Thanks for your awesome project.