### PR TITLE
Fix layout shift caused by scrollbar appearance on long content in Windows

### DIFF
--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -5,3 +5,8 @@
 
 @import 'reset', 'container', 'float', 'header', 'footer', 'page', 'post-list',
   'post', 'highlighter', 'mobile', 'printer', 'task-list', 'mermaid';
+
+/* 添加全局样式 */
+html {
+  scrollbar-gutter: stable;
+}


### PR DESCRIPTION
**Problem**
On Windows, when content becomes long enough to require scrolling, the appearance of a scrollbar causes the page content to shift to the left. This layout shift does not occur on macOS.
On Windows, scrollbars typically occupy space within the viewport, reducing the available width for content when they appear.
On macOS, scrollbars are usually overlay-style by default, meaning they float above the content without taking up additional space. This design choice prevents layout shifts when scrollbars appear or disappear.
![layout shift caused by scrollbar appearance on long content in Windows](https://github.com/user-attachments/assets/e9847392-55ce-478d-a048-085978617bf0)

**Solution**
Implement the scrollbar-gutter: stable CSS property to reserve space for the scrollbar, preventing layout shifts when the scrollbar appears or disappears on long content.

```
/* 添加全局样式 */
html {
  scrollbar-gutter: stable;
}
```