### PR TITLE
Fix inline MathJax $...$ parsing and optimize long formulas for desktop/mobile

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,12 +31,95 @@
 {% if site.analytics %}
   {% include analytics.html %}
 {% endif %}
+
 {% if site.mathjax %}
 <script
   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
   async>
 </script>
+
+<style>
+.math-container {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  padding: 10px 0;
+  margin: 1em 0;
+}
+
+.math-container::-webkit-scrollbar {
+  height: 8px;
+}
+
+.math-container::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 4px;
+}
+
+.math-container::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.inline-math-container {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  vertical-align: middle;
+  padding: 0 2px;
+}
+
+.inline-math-container::-webkit-scrollbar {
+  height: 4px;
+}
+
+.inline-math-container::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 2px;
+}
+</style>
+
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+  tex2jax: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$', '$$'], ['\\[', '\\]']],
+    processEscapes: true
+  },
+  CommonHTML: {
+    scale: 100,
+    minScaleAdjust: 100,
+    linebreaks: { automatic: false }
+  },
+  "HTML-CSS": {
+    linebreaks: { automatic: false }
+  },
+  SVG: {
+    linebreaks: { automatic: false }
+  }
+});
+
+MathJax.Hub.Queue(function() {
+  
+  var mathElements = document.querySelectorAll('.MathJax, .MathJax_CHTML, .MathJax_SVG');
+  
+  mathElements.forEach(function(element) {
+    var isDisplayMode = element.parentNode.className.indexOf('display') !== -1;
+    
+    var container = document.createElement('div');
+    container.className = isDisplayMode ? 'math-container' : 'inline-math-container';
+    
+    element.parentNode.insertBefore(container, element);
+    container.appendChild(element);
+    
+    element.style.fontSize = '100%';
+  });
+});
+</script>
 {% endif %}
+
 {% if site.diagram %}
 <script src="{{ site.baseurl }}/assets/scripts/jekyllpaper.js" async></script>
 <script


### PR DESCRIPTION
**Problem**

1. `$...$` cannot be parsed

This is because the MathJax configuration does not support or explicitly enable `$` symbols as delimiters for inline math.

2. Very long formulas, like this one: `$$(q_r\cos(m\theta) - q_i\sin(m\theta)) + i(q_r\sin(m\theta) + q_i\cos(m\theta))(test+test+test+test+test+test)$$` are not displayed properly.

Ensuring clarity when viewing long academic formulas: I require no line breaks and no scaling.

<img width="656" alt="截圖 2024-10-22 16 45 20" src="https://github.com/user-attachments/assets/f8416704-71b9-459d-98cb-c0fbb2a3af9f">

**Solution**

1. Add `$...$` support in MathJax.

2. Implement better responsive display by adding horizontal scrolling and smarter scaling logic.

```
{% if site.mathjax %}
<script
  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
  async>
</script>

<style>
.math-container {
  max-width: 100%;
  overflow-x: auto;
  overflow-y: hidden;
  -webkit-overflow-scrolling: touch;
  padding: 10px 0;
  margin: 1em 0;
}

.math-container::-webkit-scrollbar {
  height: 8px;
}

.math-container::-webkit-scrollbar-thumb {
  background: #ccc;
  border-radius: 4px;
}

.math-container::-webkit-scrollbar-track {
  background: #f1f1f1;
}

.inline-math-container {
  display: inline-block;
  max-width: 100%;
  overflow-x: auto;
  overflow-y: hidden;
  -webkit-overflow-scrolling: touch;
  vertical-align: middle;
  padding: 0 2px;
}

.inline-math-container::-webkit-scrollbar {
  height: 4px;
}

.inline-math-container::-webkit-scrollbar-thumb {
  background: #ccc;
  border-radius: 2px;
}
</style>

<script type="text/x-mathjax-config">
MathJax.Hub.Config({
  tex2jax: {
    inlineMath: [['$', '$'], ['\\(', '\\)']],
    displayMath: [['$$', '$$'], ['\\[', '\\]']],
    processEscapes: true
  },
  CommonHTML: {
    scale: 100,
    minScaleAdjust: 100,
    linebreaks: { automatic: false }
  },
  "HTML-CSS": {
    linebreaks: { automatic: false }
  },
  SVG: {
    linebreaks: { automatic: false }
  }
});

MathJax.Hub.Queue(function() {
  
  var mathElements = document.querySelectorAll('.MathJax, .MathJax_CHTML, .MathJax_SVG');
  
  mathElements.forEach(function(element) {
    var isDisplayMode = element.parentNode.className.indexOf('display') !== -1;
    
    var container = document.createElement('div');
    container.className = isDisplayMode ? 'math-container' : 'inline-math-container';
    
    element.parentNode.insertBefore(container, element);
    container.appendChild(element);
    
    element.style.fontSize = '100%';
  });
});
</script>
{% endif %}
```

In this code, I integrate MathJax to render mathematical formulas, while ensuring that long equations display properly. I’ve added custom styles to handle horizontal scrolling for both block (display) and inline math, using `.math-container` and `.inline-math-container` classes. To make the scrolling smoother on mobile, I’ve used `-webkit-overflow-scrolling: touch`. I also configured MathJax to support `$...$` for inline math, and disabled automatic line breaks in formulas across all rendering modes (CommonHTML, HTML-CSS, SVG). After MathJax renders the equations, I wrap them in scrollable containers to ensure they remain readable, even when they’re too long for the screen.

**Result**

![animation](https://github.com/user-attachments/assets/6f66eb14-6df8-4145-b128-88f322cfdecd)
