### PR TITLE
Add automatic dark mode

### DIFF
--- a/_sass/highlighter.scss
+++ b/_sass/highlighter.scss
@@ -1,19 +1,41 @@
 @charset "utf-8";
 
+// Variables for light and dark modes
+// Default
+.highlight{
+  --border-color: #ccc;
+  --box-background-color: #eee;
+  --box-shadow: rgba(0, 0, 0, 0.1);
+}
+.highlighter-rouge{
+  --background-color-rouge: #eee;
+}
+// Overrides
+@media (prefers-color-scheme: dark){
+  .highlight{
+    --border-color: darkgrey;
+    --box-background-color: #111;
+    --box-shadow: #888;
+  }
+  .highlighter-rouge{
+    --background-color-rouge: #444;
+  }
+}
+
 .highlight > pre,
 pre.highlight {
   line-height: 18px;
   margin: 10px 0;
   padding-left: 3px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--border-color);
   overflow-x: auto;
   font-size: 14px;
   text-indent: 0px;
-  background-color: #eee;
-  box-shadow: 3px 3px rgba(0, 0, 0, 0.1);
+  background-color: var(--box-background-color);
+  box-shadow: 3px 3px var(--box-shadow);
 }
 
 .highlighter-rouge {
   font-size: 14px;
-  background-color: #eee;
+  background-color: var(--background-color-rouge);
 }

--- a/_sass/reset.scss
+++ b/_sass/reset.scss
@@ -1,5 +1,24 @@
 @charset "utf-8";
 
+// Variables for light and dark mode
+// Default
+th,
+tbody{
+  --background-color: #f5f5f5;
+}
+
+// Dark mode
+@media (prefers-color-scheme: dark) {
+  body,
+  a,
+  th,
+  tbody{
+    --main-text-color: white;
+    --main-background-color: #222;
+    --background-color: #444;
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -9,11 +28,13 @@
 html,
 body {
   height: 100%;
+  background-color: var(--main-background-color);
+  color: var(--main-text-color);
 }
 
 a {
   text-decoration: none;
-  color: #000;
+  color: var(--main-text-color);
 }
 
 a:hover {
@@ -64,7 +85,7 @@ table {
 }
 
 tbody tr:hover {
-  background-color: #f5f5f5;
+  background-color: var(--background-color);
 }
 
 td {
@@ -75,7 +96,7 @@ td {
 th {
   padding: 8px;
   border-bottom: 1px solid #ccc;
-  background: #f5f5f5;
+  background: var(--background-color);
 }
 
 // markdown reset

--- a/assets/css/highlight.scss
+++ b/assets/css/highlight.scss
@@ -353,6 +353,11 @@
     color: #a52a2a;
   }
 
+  // Preprocessor values such as <stdio.h> in C
+  .cpf {
+    color: #000;
+  }
+
   // Comments that end at the end of the line
   .c1 {
     font-style: italic;

--- a/assets/css/highlight.scss
+++ b/assets/css/highlight.scss
@@ -4,10 +4,17 @@
 /**
  * highlight tokens
  * based on rougify command
- * tokens list: https://github.com/jneen/rouge/wiki/List-of-tokens 
+ * tokens list: https://github.com/jneen/rouge/wiki/List-of-tokens
  */
 
 @charset "utf-8";
+
+// Overrides
+@media (prefers-color-scheme: dark){
+  code{
+    filter: invert(1) hue-rotate(180deg);
+  }
+}
 
 .highlight {
   table {


### PR DESCRIPTION
Adds automatic dark mode according to user preferences. This PR also adds styles for the `cpf` class.

Bear in mind that colours have been hand-chosen, except for code blocks, where I simple invert and hue rotate the existing highlighter style to good effect.